### PR TITLE
Add RWX CI workflow and optimizer for Linux monolithic build (#3)

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -21,7 +21,7 @@ on:
     pull_request:
       init:
         commit-sha: ${{ event.git.sha }}
-        clone-url: ${{ event.github.pull_request.head.repo.clone_url }}
+        clone-url: ${{ event.github.pull_request.pull_request.head.repo.clone_url }}
         branch: ${{ event.git.branch }}
 
 base:

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -9,7 +9,7 @@
 #   2. App installed on CppDigest/llvm-project with Contents + PR permissions
 #
 # Local test:
-#   rwx run .rwx/ci.yml --init commit-sha=HEAD --init clone-url=https://github.com/CppDigest/llvm-project.git --init branch=main
+#   rwx run .rwx/ci.yml --init commit-sha=HEAD
 #
 
 on:
@@ -24,16 +24,6 @@ on:
         commit-sha: ${{ event.git.sha }}
         clone-url: ${{ event.github.pull_request.head.repo.clone_url }}
         branch: ${{ event.pull_request.head.ref }}
-
-concurrency-pools:
-  - id: cppdigest/llvm-project:main
-    if: ${{ init.branch == 'main' }}
-    capacity: 1
-    on-overflow: cancel-waiting
-  - id: cppdigest/llvm-project:pr
-    if: ${{ init.branch != 'main' }}
-    capacity: 1
-    on-overflow: cancel-running
 
 base:
   image: ubuntu:24.04

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -8,8 +8,7 @@
 #   1. RWX org with GitHub App "CppDigest" (slug: cppdigest-test) in Vault
 #   2. App installed on CppDigest/llvm-project with Contents + PR permissions
 #
-# Local test:
-#   rwx run .rwx/ci.yml --init commit-sha=HEAD
+# Local test: rwx run .rwx/ci.yml --init commit-sha=HEAD --init clone-url=<repo-clone-url> --init branch=<branch>
 #
 
 on:

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -22,7 +22,7 @@ on:
       init:
         commit-sha: ${{ event.git.sha }}
         clone-url: ${{ event.github.pull_request.head.repo.clone_url }}
-        branch: ${{ event.pull_request.head.ref }}
+        branch: ${{ event.git.branch }}
 
 base:
   image: ubuntu:24.04
@@ -34,9 +34,8 @@ tasks:
   - key: clone-repo
     timeout: 10m
     run: |
-      git clone --depth 1 ${{ init.clone-url }} llvm-project
+      git clone --depth 50 --branch ${{ init.branch }} ${{ init.clone-url }} llvm-project
       cd llvm-project
-      git fetch origin ${{ init.commit-sha }}
       git checkout ${{ init.commit-sha }}
     filter:
       - llvm-project/**

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -1,0 +1,494 @@
+#
+# RWX CI — CppDigest/llvm-project (Linux monolithic build)
+#
+# Migrated from .ci/monolithic-linux.sh + GitHub Actions.
+# DAG: clone → deps/sccache → configure → build → parallel checks (incl. lldb, runtimes) → report
+#
+# Prerequisites:
+#   1. RWX org with GitHub App "CppDigest" (slug: cppdigest-test) in Vault
+#   2. App installed on CppDigest/llvm-project with Contents + PR permissions
+#
+# Local test:
+#   rwx run .rwx/ci.yml --init commit-sha=HEAD --init clone-url=https://github.com/CppDigest/llvm-project.git --init branch=main
+#
+
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+        clone-url: ${{ event.github.push.repository.clone_url }}
+        branch: ${{ event.git.branch }}
+    pull_request:
+      init:
+        commit-sha: ${{ event.git.sha }}
+        clone-url: ${{ event.github.pull_request.head.repo.clone_url }}
+        branch: ${{ event.pull_request.head.ref }}
+
+concurrency-pools:
+  - id: cppdigest/llvm-project:main
+    if: ${{ init.branch == 'main' }}
+    capacity: 1
+    on-overflow: cancel-waiting
+  - id: cppdigest/llvm-project:pr
+    if: ${{ init.branch != 'main' }}
+    capacity: 1
+    on-overflow: cancel-running
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
+
+tasks:
+  # ---------- Stage 1: clone + toolchain ----------
+
+  - key: clone-repo
+    timeout: 10m
+    run: |
+      git clone --depth 1 ${{ init.clone-url }} llvm-project
+      cd llvm-project
+      git fetch origin ${{ init.commit-sha }}
+      git checkout ${{ init.commit-sha }}
+    filter:
+      - llvm-project/**
+
+  - key: install-build-deps
+    timeout: 5m
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y \
+        cmake ninja-build clang lld \
+        python3 python3-pip python-is-python3 \
+        libxml2-dev libedit-dev libncurses5-dev swig \
+        build-essential
+      pip install --break-system-packages -q lit psutil
+    cache: true
+    filter:
+      - .rwx/ci.yml
+
+  - key: install-sccache
+    timeout: 2m
+    run: |
+      wget -q https://github.com/mozilla/sccache/releases/download/v0.8.2/sccache-v0.8.2-x86_64-unknown-linux-musl.tar.gz
+      tar xzf sccache-v0.8.2-x86_64-unknown-linux-musl.tar.gz
+      sudo mv sccache-v0.8.2-x86_64-unknown-linux-musl/sccache /usr/local/bin/
+      chmod +x /usr/local/bin/sccache
+    cache: true
+    filter:
+      - .rwx/ci.yml
+
+  # ---------- Stage 2: cmake configure ----------
+
+  - key: cmake-configure
+    use: [clone-repo, install-build-deps, install-sccache]
+    timeout: 15m
+    agent:
+      cpus: 8
+      memory: 32GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      sccache --zero-stats
+
+      cmake -S "$WORKSPACE_ROOT/llvm-project/llvm" -B "$BUILD_DIR" \
+        -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb;mlir;polly;bolt;flang" \
+        -D LLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
+        -G Ninja \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D LLVM_ENABLE_ASSERTIONS=ON \
+        -D LLVM_BUILD_EXAMPLES=ON \
+        -D COMPILER_RT_BUILD_LIBFUZZER=OFF \
+        -D LLVM_LIT_ARGS="-v --xunit-xml-output $BUILD_DIR/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests --succinct" \
+        -D LLVM_ENABLE_LLD=ON \
+        -D CMAKE_CXX_FLAGS=-gmlt \
+        -D CMAKE_C_COMPILER_LAUNCHER=sccache \
+        -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \
+        -D CMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
+        -D LIBCXX_CXX_ABI=libcxxabi \
+        -D MLIR_ENABLE_BINDINGS_PYTHON=ON \
+        -D LLDB_ENABLE_PYTHON=ON \
+        -D LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=ON \
+        -D CMAKE_INSTALL_PREFIX="$BUILD_DIR/install" \
+        -D CMAKE_EXE_LINKER_FLAGS="-no-pie" \
+        -D LLVM_ENABLE_WERROR=ON
+    cache: true
+    filter:
+      - llvm-project/llvm/CMakeLists.txt
+      - llvm-project/clang/CMakeLists.txt
+      - llvm-project/cmake/**
+      - tmp/sccache/**
+      - .rwx/ci.yml
+
+  # ---------- Stage 3: build core ----------
+
+  - key: build-llvm-core
+    use: [cmake-configure]
+    timeout: 90m
+    agent:
+      cpus: 16
+      memory: 64GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 \
+        llvm-libraries clang lld \
+        llvm-ar llvm-nm llvm-objcopy llvm-objdump llvm-symbolizer \
+        2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-core.log"
+
+      TASK_END=$(date +%s)
+      sccache --show-stats
+
+      # Write timing to unique file (avoids merge conflicts in parallel tasks)
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|build-llvm-core|SUCCESS" > "$WORKSPACE_ROOT/tmp/timing/build-llvm-core.log"
+      sccache --show-stats > "$WORKSPACE_ROOT/tmp/timing/sccache-build.txt" 2>&1
+    cache: true
+    filter:
+      - llvm-project/llvm/**
+      - llvm-project/clang/**
+      - llvm-project/lld/**
+      - tmp/sccache/**
+
+  # ---------- Stage 4: parallel checks ----------
+  #
+  # Each check task writes timing to its own file under tmp/timing/
+  # to avoid file-merge conflicts when performance-analysis reads them.
+
+  - key: check-llvm
+    use: [build-llvm-core]
+    timeout: 30m
+    agent:
+      cpus: 8
+      memory: 32GB
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" check-llvm 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-llvm.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-llvm|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-llvm.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/llvm/**
+
+  - key: check-clang
+    use: [build-llvm-core]
+    timeout: 30m
+    agent:
+      cpus: 8
+      memory: 32GB
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" check-clang 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-clang.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-clang|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-clang.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/clang/**
+      - llvm-project/llvm/**
+
+  - key: check-lld
+    use: [build-llvm-core]
+    timeout: 15m
+    agent:
+      cpus: 4
+      memory: 16GB
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" check-lld 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-lld.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-lld|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-lld.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/lld/**
+      - llvm-project/llvm/**
+
+  - key: check-mlir
+    use: [build-llvm-core]
+    timeout: 45m
+    agent:
+      cpus: 8
+      memory: 32GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 mlir-libraries 2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-mlir.log"
+      ninja -C "$BUILD_DIR" check-mlir 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-mlir.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-mlir|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-mlir.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/mlir/**
+      - llvm-project/llvm/**
+      - tmp/sccache/**
+
+  - key: check-bolt
+    use: [build-llvm-core]
+    timeout: 15m
+    agent:
+      cpus: 4
+      memory: 16GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 bolt 2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-bolt.log"
+      ninja -C "$BUILD_DIR" check-bolt 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-bolt.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-bolt|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-bolt.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/bolt/**
+      - llvm-project/llvm/**
+      - tmp/sccache/**
+
+  - key: check-polly
+    use: [build-llvm-core]
+    timeout: 15m
+    agent:
+      cpus: 4
+      memory: 16GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 polly 2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-polly.log"
+      ninja -C "$BUILD_DIR" check-polly 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-polly.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-polly|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-polly.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/polly/**
+      - llvm-project/llvm/**
+      - tmp/sccache/**
+
+  - key: check-flang
+    use: [build-llvm-core]
+    timeout: 30m
+    agent:
+      cpus: 8
+      memory: 32GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 flang 2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-flang.log"
+      ninja -C "$BUILD_DIR" check-flang 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-flang.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-flang|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-flang.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/flang/**
+      - llvm-project/llvm/**
+      - tmp/sccache/**
+
+  - key: check-clang-tools
+    use: [build-llvm-core]
+    timeout: 30m
+    agent:
+      cpus: 8
+      memory: 32GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 clang-tools 2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-clang-tools.log"
+      ninja -C "$BUILD_DIR" check-clang-tools 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-clang-tools.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-clang-tools|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-clang-tools.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/clang-tools-extra/**
+      - llvm-project/clang/**
+      - llvm-project/llvm/**
+      - tmp/sccache/**
+
+  - key: check-lldb
+    use: [build-llvm-core]
+    timeout: 45m
+    agent:
+      cpus: 8
+      memory: 32GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      ninja -C "$BUILD_DIR" -k 0 lldb 2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-lldb.log"
+      ninja -C "$BUILD_DIR" check-lldb 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-lldb.log"
+      RETCODE=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      STATUS=$( [ $RETCODE -eq 0 ] && echo "SUCCESS" || echo "FAIL" )
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-lldb|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-lldb.log"
+      exit $RETCODE
+    filter:
+      - llvm-project/lldb/**
+      - llvm-project/llvm/**
+      - tmp/sccache/**
+
+  # ---------- Stage 4b: runtime build + tests (compiler-rt, libcxx/libcxxabi/libunwind with C++26 and Clang Modules) ----------
+
+  - key: check-runtimes
+    use: [build-llvm-core]
+    timeout: 60m
+    agent:
+      cpus: 8
+      memory: 32GB
+    env:
+      SCCACHE_CACHE_SIZE: 5G
+    run: |
+      TASK_START=$(date +%s)
+      WORKSPACE_ROOT=$(pwd)
+      export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
+      BUILD_DIR="$WORKSPACE_ROOT/build"
+
+      # Build and test compiler-rt
+      ninja -C "$BUILD_DIR" check-compiler-rt 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-compiler-rt.log"
+      RET1=${PIPESTATUS[0]}
+
+      # Reconfig for libcxx/libcxxabi/libunwind C++26, then build and test
+      cmake -D LIBCXX_TEST_PARAMS="std=c++26" -D LIBCXXABI_TEST_PARAMS="std=c++26" "$BUILD_DIR"
+      ninja -C "$BUILD_DIR" check-cxx check-cxxabi check-unwind 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-runtimes-cxx26.log"
+      RET2=${PIPESTATUS[0]}
+
+      # Reconfig for Clang Modules, then build and test again
+      cmake -D LIBCXX_TEST_PARAMS="enable_modules=clang" -D LIBCXXABI_TEST_PARAMS="enable_modules=clang" "$BUILD_DIR"
+      ninja -C "$BUILD_DIR" check-cxx check-cxxabi check-unwind 2>&1 | tee "$WORKSPACE_ROOT/tmp/check-runtimes-modules.log"
+      RET3=${PIPESTATUS[0]}
+
+      TASK_END=$(date +%s)
+      if [ $RET1 -eq 0 ] && [ $RET2 -eq 0 ] && [ $RET3 -eq 0 ]; then STATUS="SUCCESS"; else STATUS="FAIL"; fi
+      mkdir -p "$WORKSPACE_ROOT/tmp/timing"
+      echo "$((TASK_END - TASK_START))|check-runtimes|${STATUS}" > "$WORKSPACE_ROOT/tmp/timing/check-runtimes.log"
+      [ $RET1 -eq 0 ] && [ $RET2 -eq 0 ] && [ $RET3 -eq 0 ] || exit 1
+    filter:
+      - llvm-project/compiler-rt/**
+      - llvm-project/libcxx/**
+      - llvm-project/libcxxabi/**
+      - llvm-project/libunwind/**
+      - llvm-project/llvm/**
+      - llvm-project/clang/**
+      - tmp/sccache/**
+
+  # ---------- Stage 5: report (runs even if checks fail) ----------
+
+  - key: performance-analysis
+    after: ${{ (check-llvm.succeeded || check-llvm.failed) && (check-clang.succeeded || check-clang.failed) && (check-lld.succeeded || check-lld.failed) && (check-mlir.succeeded || check-mlir.failed) && (check-bolt.succeeded || check-bolt.failed) && (check-polly.succeeded || check-polly.failed) && (check-flang.succeeded || check-flang.failed) && (check-clang-tools.succeeded || check-clang-tools.failed) && (check-lldb.succeeded || check-lldb.failed) && (check-runtimes.succeeded || check-runtimes.failed) }}
+    use: [check-llvm, check-clang, check-lld, check-mlir, check-bolt, check-polly, check-flang, check-clang-tools, check-lldb, check-runtimes]
+    timeout: 5m
+    run: |
+      echo ""
+      echo "=== RWX CI PERFORMANCE REPORT — LLVM ==="
+      echo ""
+
+      WORKSPACE_ROOT=$(pwd)
+      TIMING_DIR="$WORKSPACE_ROOT/tmp/timing"
+
+      if ls "$TIMING_DIR"/*.log 1>/dev/null 2>&1; then
+        echo "Task Timings (sorted by duration):"
+        echo "------------------------------------------------------------"
+        cat "$TIMING_DIR"/*.log | sort -t'|' -k1 -rn | while IFS='|' read -r duration task status; do
+          printf "  %-30s %6ss  [%s]\n" "$task" "$duration" "$status"
+        done
+        echo ""
+
+        TOTAL=0
+        while IFS='|' read -r duration task status; do
+          TOTAL=$((TOTAL + duration))
+        done < <(cat "$TIMING_DIR"/*.log)
+        echo "Sequential total: ${TOTAL}s"
+
+        FAILURES=$(cat "$TIMING_DIR"/*.log | grep "FAIL" | wc -l)
+        if [ "$FAILURES" -gt 0 ]; then
+          echo ""
+          echo "FAILED:"
+          cat "$TIMING_DIR"/*.log | grep "FAIL" | while IFS='|' read -r d t s; do
+            echo "  - $t (${d}s)"
+          done
+        fi
+      else
+        echo "No timing data found."
+      fi
+
+      echo ""
+      if [ -f "$TIMING_DIR/sccache-build.txt" ]; then
+        echo "Sccache (build-llvm-core):"
+        echo "------------------------------------------------------------"
+        cat "$TIMING_DIR/sccache-build.txt"
+      fi
+    filter:
+      - .rwx/ci.yml

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -69,10 +69,10 @@ tasks:
 
   - key: cmake-configure
     use: [clone-repo, install-build-deps, install-sccache]
-    timeout: 15m
+    timeout: 30m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -115,10 +115,10 @@ tasks:
 
   - key: build-llvm-core
     use: [cmake-configure]
-    timeout: 90m
+    timeout: 180m
     agent:
-      cpus: 16
-      memory: 64GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -127,7 +127,7 @@ tasks:
       export SCCACHE_DIR="$WORKSPACE_ROOT/tmp/sccache"
       BUILD_DIR="$WORKSPACE_ROOT/build"
 
-      ninja -C "$BUILD_DIR" -k 0 \
+      ninja -C "$BUILD_DIR" -j2 -k 0 \
         llvm-libraries clang lld \
         llvm-ar llvm-nm llvm-objcopy llvm-objdump llvm-symbolizer \
         2>&1 | tee "$WORKSPACE_ROOT/tmp/ninja-core.log"
@@ -153,10 +153,10 @@ tasks:
 
   - key: check-llvm
     use: [build-llvm-core]
-    timeout: 30m
+    timeout: 60m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     run: |
       TASK_START=$(date +%s)
       WORKSPACE_ROOT=$(pwd)
@@ -175,10 +175,10 @@ tasks:
 
   - key: check-clang
     use: [build-llvm-core]
-    timeout: 30m
+    timeout: 60m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     run: |
       TASK_START=$(date +%s)
       WORKSPACE_ROOT=$(pwd)
@@ -198,10 +198,10 @@ tasks:
 
   - key: check-lld
     use: [build-llvm-core]
-    timeout: 15m
+    timeout: 30m
     agent:
-      cpus: 4
-      memory: 16GB
+      cpus: 2
+      memory: 8GB
     run: |
       TASK_START=$(date +%s)
       WORKSPACE_ROOT=$(pwd)
@@ -221,10 +221,10 @@ tasks:
 
   - key: check-mlir
     use: [build-llvm-core]
-    timeout: 45m
+    timeout: 90m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -249,10 +249,10 @@ tasks:
 
   - key: check-bolt
     use: [build-llvm-core]
-    timeout: 15m
+    timeout: 30m
     agent:
-      cpus: 4
-      memory: 16GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -277,10 +277,10 @@ tasks:
 
   - key: check-polly
     use: [build-llvm-core]
-    timeout: 15m
+    timeout: 30m
     agent:
-      cpus: 4
-      memory: 16GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -305,10 +305,10 @@ tasks:
 
   - key: check-flang
     use: [build-llvm-core]
-    timeout: 30m
+    timeout: 60m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -333,10 +333,10 @@ tasks:
 
   - key: check-clang-tools
     use: [build-llvm-core]
-    timeout: 30m
+    timeout: 60m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -362,10 +362,10 @@ tasks:
 
   - key: check-lldb
     use: [build-llvm-core]
-    timeout: 45m
+    timeout: 90m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |
@@ -392,10 +392,10 @@ tasks:
 
   - key: check-runtimes
     use: [build-llvm-core]
-    timeout: 60m
+    timeout: 120m
     agent:
-      cpus: 8
-      memory: 32GB
+      cpus: 2
+      memory: 8GB
     env:
       SCCACHE_CACHE_SIZE: 5G
     run: |

--- a/.rwx/optimizer.sh
+++ b/.rwx/optimizer.sh
@@ -1,0 +1,556 @@
+#!/usr/bin/env bash
+#
+# RWX CI Optimizer — iterative Claude Code optimization loop
+#
+# Runs the RWX workflow, extracts timing/failure data, feeds it to Claude Code,
+# validates the changes, commits, and repeats. Stops on convergence or cap.
+#
+# Prerequisites:
+#   - rwx CLI installed and authenticated
+#   - claude CLI (Claude Code) installed
+#   - git repo with .rwx/ci.yml committed
+#
+# Usage:
+#   ./optimizer.sh                          # 1 session, 20 iterations
+#   ./optimizer.sh --sessions 3             # 3 sessions of 20 iterations
+#   ./optimizer.sh --max-iter 10            # override iterations per session
+#   ./optimizer.sh --dry-run                # show what would be done
+#   ./optimizer.sh --target-seconds 300     # stop optimizing once under 5 min
+#
+# References:
+#   - Gist: https://gist.github.com/iTinkerBell/864cd6f1d4fcab339bb535d4b6462e7e
+#   - RWX packages: https://github.com/rwx-cloud/packages
+#   - Capy RWX CI: CppDigest/capy .rwx/ci.yml
+#
+
+set -euo pipefail
+
+# ── config ──────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW_FILE="$SCRIPT_DIR/ci.yml"
+LOG_BASE_DIR="$SCRIPT_DIR/optimizer-logs"
+
+MAX_ITERATIONS="${MAX_ITERATIONS:-20}"
+MAX_SESSIONS="${MAX_SESSIONS:-1}"
+DRY_RUN="${DRY_RUN:-false}"
+TARGET_RUNTIME_SECONDS="${TARGET_RUNTIME_SECONDS:-300}"   # stop if total < this
+LOG_AVAILABILITY_TIMEOUT="${LOG_AVAILABILITY_TIMEOUT:-90}" # seconds to wait for RWX logs
+COMMIT_SHA="${COMMIT_SHA:-HEAD}"
+CLONE_URL="${CLONE_URL:-https://github.com/CppDigest/llvm-project.git}"
+
+BLOCKLIST_FILE="$LOG_BASE_DIR/blocklist.txt"
+
+# ── parse args ──────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --sessions)          MAX_SESSIONS="$2";          shift 2 ;;
+    --max-iter)          MAX_ITERATIONS="$2";        shift 2 ;;
+    --dry-run)           DRY_RUN=true;               shift   ;;
+    --target-seconds)    TARGET_RUNTIME_SECONDS="$2"; shift 2 ;;
+    --commit-sha)        COMMIT_SHA="$2";            shift 2 ;;
+    --clone-url)         CLONE_URL="$2";             shift 2 ;;
+    --help)
+      echo "Usage: $0 [--sessions N] [--max-iter N] [--target-seconds N] [--dry-run]"
+      exit 0 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# ── pre-flight checks ──────────────────────────────────────────────
+
+preflight() {
+  local ok=true
+
+  if [ ! -f "$WORKFLOW_FILE" ]; then
+    echo "ERROR: $WORKFLOW_FILE not found"; ok=false
+  fi
+
+  if ! command -v rwx &>/dev/null; then
+    echo "ERROR: rwx CLI not installed (https://www.rwx.com/docs/mint/cli)"; ok=false
+  fi
+
+  if ! command -v claude &>/dev/null; then
+    echo "ERROR: claude CLI not installed"; ok=false
+  fi
+
+  if ! command -v git &>/dev/null; then
+    echo "ERROR: git not installed"; ok=false
+  fi
+
+  if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "ERROR: $REPO_ROOT is not a git repository"; ok=false
+  fi
+
+  if ! python3 -c "import yaml" &>/dev/null 2>&1; then
+    echo "WARNING: python3 pyyaml not installed — YAML validation will be skipped"
+  fi
+
+  if [ "$ok" = false ]; then
+    echo "Pre-flight failed. Fix the errors above."
+    exit 1
+  fi
+}
+
+# ── logging ─────────────────────────────────────────────────────────
+
+SESSION_ID=""
+SESSION_DIR=""
+
+init_session() {
+  SESSION_ID="$(date +%Y%m%d-%H%M%S)-$$"
+  SESSION_DIR="$LOG_BASE_DIR/session-$SESSION_ID"
+  mkdir -p "$SESSION_DIR"
+
+  cp "$WORKFLOW_FILE" "$SESSION_DIR/ci.yml.initial"
+
+  log "session started | max_iter=$MAX_ITERATIONS target=${TARGET_RUNTIME_SECONDS}s"
+}
+
+init_iteration() {
+  local iter=$1
+  local pad; pad=$(printf '%03d' "$iter")
+  cp "$WORKFLOW_FILE" "$SESSION_DIR/ci.yml.iter-${pad}.before"
+  log "--- iteration $iter/$MAX_ITERATIONS ---"
+}
+
+log() {
+  local ts; ts=$(date '+%H:%M:%S')
+  echo "[$ts] $*" | tee -a "$SESSION_DIR/session.log"
+}
+
+# ── rwx run + metrics ──────────────────────────────────────────────
+
+run_rwx() {
+  local iter=$1
+  local pad; pad=$(printf '%03d' "$iter")
+  local output="$SESSION_DIR/rwx-output-${pad}.txt"
+  local run_id_file="$SESSION_DIR/rwx-run-id-${pad}.txt"
+
+  if [ "$DRY_RUN" = true ]; then
+    log "[dry-run] would run: rwx run .rwx/ci.yml"
+    echo "dry-run" > "$SESSION_DIR/rwx-status-${pad}.txt"
+    return 0
+  fi
+
+  log "running rwx workflow..."
+  cd "$REPO_ROOT"
+
+  local start_ts; start_ts=$(date +%s)
+
+  # Capture run ID from rwx output for log download
+  if rwx run .rwx/ci.yml \
+       --init "commit-sha=$COMMIT_SHA" \
+       --init "clone-url=$CLONE_URL" \
+       --init "branch=optimizer" \
+       2>&1 | tee "$output"; then
+    local end_ts; end_ts=$(date +%s)
+    local wall=$((end_ts - start_ts))
+    log "rwx PASSED (wall: ${wall}s)"
+    echo "SUCCESS|${wall}" > "$SESSION_DIR/rwx-status-${pad}.txt"
+
+    # Check if we hit the target
+    if [ "$wall" -le "$TARGET_RUNTIME_SECONDS" ]; then
+      log "target reached: ${wall}s <= ${TARGET_RUNTIME_SECONDS}s"
+      return 2  # special code: target met
+    fi
+    return 0
+  else
+    local rc=$?
+    local end_ts; end_ts=$(date +%s)
+    local wall=$((end_ts - start_ts))
+    log "rwx FAILED (exit=$rc, wall: ${wall}s)"
+    echo "FAIL|${wall}|exit=$rc" > "$SESSION_DIR/rwx-status-${pad}.txt"
+    return 1
+  fi
+}
+
+extract_metrics() {
+  local iter=$1
+  local pad; pad=$(printf '%03d' "$iter")
+  local output="$SESSION_DIR/rwx-output-${pad}.txt"
+  local metrics="$SESSION_DIR/metrics-${pad}.txt"
+
+  # Pull timing markers and errors from rwx output
+  if [ -f "$output" ]; then
+    grep -E "completed in|FAIL|ERROR|TASK:|sccache|Compile requests" \
+      "$output" > "$metrics" 2>/dev/null || true
+  fi
+
+  # Append status
+  if [ -f "$SESSION_DIR/rwx-status-${pad}.txt" ]; then
+    echo "---" >> "$metrics"
+    cat "$SESSION_DIR/rwx-status-${pad}.txt" >> "$metrics"
+  fi
+
+  log "metrics saved ($(wc -l < "$metrics") lines)"
+}
+
+download_failure_logs() {
+  local iter=$1
+  local pad; pad=$(printf '%03d' "$iter")
+  local output="$SESSION_DIR/rwx-output-${pad}.txt"
+  local failure="$SESSION_DIR/failure-${pad}.txt"
+
+  : > "$failure"
+
+  # Try rwx CLI for structured failure info
+  if command -v rwx &>/dev/null; then
+    # Extract task IDs from output (UUIDs in RWX output)
+    local task_ids
+    task_ids=$(grep -oP '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+      "$output" 2>/dev/null | sort -u || true)
+
+    for tid in $task_ids; do
+      log "downloading logs for task $tid..."
+      local waited=0
+      while [ "$waited" -lt "$LOG_AVAILABILITY_TIMEOUT" ]; do
+        if rwx tasks logs "$tid" >> "$failure" 2>/dev/null; then
+          break
+        fi
+        sleep 5
+        waited=$((waited + 5))
+      done
+    done
+  fi
+
+  # Also grab error context from raw output
+  if [ -f "$output" ]; then
+    grep -A 10 -E "^error:|^FAIL|fatal:" "$output" >> "$failure" 2>/dev/null || true
+  fi
+
+  if [ -s "$failure" ]; then
+    log "failure logs saved ($(wc -l < "$failure") lines)"
+  fi
+}
+
+# ── validation ──────────────────────────────────────────────────────
+
+validate_yaml() {
+  # Syntax check
+  if command -v python3 &>/dev/null && python3 -c "import yaml" &>/dev/null 2>&1; then
+    if ! python3 -c "
+import yaml, sys
+with open(sys.argv[1]) as f:
+    yaml.safe_load(f)
+" "$WORKFLOW_FILE" 2>&1; then
+      log "YAML syntax invalid"
+      return 1
+    fi
+  fi
+
+  # Known-bad patterns
+  local bad_patterns=(
+    "depinst.py --jobs"
+    "git submodule.*--single-branch"
+    "ubuntu:25.04"
+  )
+  for pat in "${bad_patterns[@]}"; do
+    if grep -qP "$pat" "$WORKFLOW_FILE"; then
+      log "found known-bad pattern: $pat"
+      return 1
+    fi
+  done
+
+  # Sanity: make sure key tasks still exist
+  local required_keys=(clone-repo cmake-configure build-llvm-core check-llvm check-clang)
+  for key in "${required_keys[@]}"; do
+    if ! grep -q "key: $key" "$WORKFLOW_FILE"; then
+      log "required task '$key' missing from workflow"
+      return 1
+    fi
+  done
+
+  log "validation passed"
+  return 0
+}
+
+check_oscillation() {
+  local iter=$1
+  [ "$iter" -lt 3 ] && return 0
+
+  local cur="$SESSION_DIR/ci.yml.iter-$(printf '%03d' "$iter").before"
+  local prev2="$SESSION_DIR/ci.yml.iter-$(printf '%03d' $((iter - 2))).before"
+
+  if [ -f "$cur" ] && [ -f "$prev2" ] && diff -q "$cur" "$prev2" &>/dev/null; then
+    log "oscillation: current matches iter $((iter - 2))"
+    return 1
+  fi
+  return 0
+}
+
+# ── claude invocation ───────────────────────────────────────────────
+
+build_prompt() {
+  local iter=$1
+  local rwx_status=$2
+  local pad; pad=$(printf '%03d' "$iter")
+  local prompt="$SESSION_DIR/prompt-${pad}.md"
+
+  cat > "$prompt" << 'HEADER'
+You are optimizing an RWX CI workflow for the LLVM project.
+Only modify .rwx/ci.yml. Keep all existing check-* tasks. Preserve the DAG structure.
+
+RWX task fields: key, use, after, run, call, with, cache, filter, env, timeout, agent, if.
+Docs: https://www.rwx.com/docs/mint  Packages: https://github.com/rwx-cloud/packages
+
+Rules:
+- sccache dir (tmp/sccache/**) MUST be in filter: for any task using sccache
+- timeout must be set on every task (default 10m is too short for LLVM)
+- agent specs must match task needs (build: 16 CPU/64GB, checks: 4-8 CPU)
+- Do NOT add flags that don't exist (e.g. depinst.py --jobs)
+- Do NOT use ubuntu:25.04 (unsupported by rwx/base)
+- Explain changes in a short comment at the top of your diff
+HEADER
+
+  echo "" >> "$prompt"
+  echo "## Iteration $iter — Status: $rwx_status" >> "$prompt"
+
+  # Metrics
+  local mf="$SESSION_DIR/metrics-${pad}.txt"
+  if [ -f "$mf" ] && [ -s "$mf" ]; then
+    echo "" >> "$prompt"
+    echo "## Metrics" >> "$prompt"
+    echo '```' >> "$prompt"
+    head -80 "$mf" >> "$prompt"
+    echo '```' >> "$prompt"
+  fi
+
+  # Failure logs
+  local ff="$SESSION_DIR/failure-${pad}.txt"
+  if [ -f "$ff" ] && [ -s "$ff" ]; then
+    echo "" >> "$prompt"
+    echo "## Failure logs (truncated)" >> "$prompt"
+    echo '```' >> "$prompt"
+    head -150 "$ff" >> "$prompt"
+    echo '```' >> "$prompt"
+  fi
+
+  # Blocklist
+  if [ -f "$BLOCKLIST_FILE" ] && [ -s "$BLOCKLIST_FILE" ]; then
+    echo "" >> "$prompt"
+    echo "## Do NOT modify these areas" >> "$prompt"
+    cat "$BLOCKLIST_FILE" >> "$prompt"
+  fi
+
+  # Current workflow
+  echo "" >> "$prompt"
+  echo "## Current .rwx/ci.yml" >> "$prompt"
+  echo '```yaml' >> "$prompt"
+  cat "$WORKFLOW_FILE" >> "$prompt"
+  echo '```' >> "$prompt"
+
+  # Task
+  echo "" >> "$prompt"
+  if [ "$rwx_status" = "SUCCESS" ]; then
+    echo "The workflow passed. Optimize the slowest tasks for speed." >> "$prompt"
+    echo "Target: total wall-clock under ${TARGET_RUNTIME_SECONDS}s." >> "$prompt"
+  else
+    echo "The workflow failed. Fix the root cause." >> "$prompt"
+  fi
+
+  echo "$prompt"
+}
+
+invoke_claude() {
+  local iter=$1
+  local prompt_file=$2
+  local pad; pad=$(printf '%03d' "$iter")
+  local output="$SESSION_DIR/claude-output-${pad}.txt"
+
+  if [ "$DRY_RUN" = true ]; then
+    log "[dry-run] would invoke: claude -p < $prompt_file"
+    return 1  # no changes in dry-run
+  fi
+
+  log "invoking claude..."
+  cd "$REPO_ROOT"
+
+  if claude -p < "$prompt_file" > "$output" 2>&1; then
+    log "claude responded"
+  else
+    log "claude failed (exit=$?)"
+    return 1
+  fi
+
+  # Did it actually change the file?
+  if git diff --quiet "$WORKFLOW_FILE" 2>/dev/null; then
+    log "claude made no changes"
+    return 1
+  fi
+
+  log "claude modified ci.yml"
+  return 0
+}
+
+# ── git ─────────────────────────────────────────────────────────────
+
+commit_changes() {
+  local iter=$1
+  local session_num=$2
+
+  if [ "$DRY_RUN" = true ]; then return 0; fi
+
+  cd "$REPO_ROOT"
+  git diff --quiet "$WORKFLOW_FILE" 2>/dev/null && return 1
+
+  git add "$WORKFLOW_FILE"
+  git commit -m "rwx-optimizer: s${session_num} i${iter}
+
+Session: $SESSION_ID
+Iteration: $iter/$MAX_ITERATIONS"
+  log "committed"
+}
+
+revert() {
+  if [ "$DRY_RUN" = true ]; then return 0; fi
+
+  cd "$REPO_ROOT"
+  if git diff --quiet "$WORKFLOW_FILE" 2>/dev/null; then
+    git revert --no-edit HEAD 2>/dev/null || git checkout HEAD~1 -- "$WORKFLOW_FILE"
+  else
+    git checkout -- "$WORKFLOW_FILE"
+  fi
+  log "reverted"
+}
+
+# ── main loop ───────────────────────────────────────────────────────
+
+run_session() {
+  local session_num=$1
+  init_session
+
+  local no_change_streak=0
+  local fail_streak=0
+
+  for ((iter=1; iter<=MAX_ITERATIONS; iter++)); do
+    init_iteration "$iter"
+
+    # Oscillation guard
+    if ! check_oscillation "$iter"; then
+      log "stopping: oscillation detected"
+      break
+    fi
+
+    # Run workflow
+    local rwx_status="SUCCESS"
+    local rwx_rc=0
+    run_rwx "$iter" || rwx_rc=$?
+
+    if [ "$rwx_rc" -eq 2 ]; then
+      log "target met — done"
+      break
+    elif [ "$rwx_rc" -ne 0 ]; then
+      rwx_status="FAIL"
+      download_failure_logs "$iter"
+      fail_streak=$((fail_streak + 1))
+    else
+      fail_streak=0
+    fi
+
+    extract_metrics "$iter"
+
+    # Build prompt, invoke claude
+    local prompt_file
+    prompt_file=$(build_prompt "$iter" "$rwx_status")
+
+    if ! invoke_claude "$iter" "$prompt_file"; then
+      no_change_streak=$((no_change_streak + 1))
+      if [ "$no_change_streak" -ge 3 ]; then
+        log "stopping: 3 iterations with no changes"
+        break
+      fi
+      continue
+    fi
+    no_change_streak=0
+
+    # Validate
+    if ! validate_yaml; then
+      log "validation failed — reverting"
+      revert
+      continue
+    fi
+
+    # Commit
+    commit_changes "$iter" "$session_num" || true
+
+    # Safety cap
+    if [ "$fail_streak" -ge 5 ]; then
+      log "stopping: 5 consecutive failures"
+      break
+    fi
+  done
+
+  cp "$WORKFLOW_FILE" "$SESSION_DIR/ci.yml.final"
+  generate_report "$session_num"
+  log "session done"
+}
+
+# ── report ──────────────────────────────────────────────────────────
+
+generate_report() {
+  local session_num=$1
+  local report="$SESSION_DIR/report.md"
+
+  cat > "$report" << EOF
+# Optimizer Report — Session $SESSION_ID
+
+**Repo:** CppDigest/llvm-project
+**Session:** $session_num / $MAX_SESSIONS
+**Target:** ${TARGET_RUNTIME_SECONDS}s
+
+| Iter | RWX | Wall | Changed | Committed |
+|------|-----|------|---------|-----------|
+EOF
+
+  for f in "$SESSION_DIR"/rwx-status-*.txt; do
+    [ -f "$f" ] || continue
+    local pad; pad=$(basename "$f" | grep -oP '\d{3}')
+    local num=$((10#$pad))
+    local status; status=$(cut -d'|' -f1 < "$f")
+    local wall; wall=$(cut -d'|' -f2 < "$f" 2>/dev/null || echo "-")
+
+    local changed="no"
+    local committed="no"
+    local before="$SESSION_DIR/ci.yml.iter-${pad}.before"
+    local next_pad; next_pad=$(printf '%03d' $((num + 1)))
+    local after_file="$SESSION_DIR/ci.yml.iter-${next_pad}.before"
+    if [ -f "$before" ] && [ -f "$after_file" ]; then
+      diff -q "$before" "$after_file" &>/dev/null || { changed="yes"; committed="yes"; }
+    fi
+
+    echo "| $num | $status | ${wall}s | $changed | $committed |" >> "$report"
+  done
+
+  echo "" >> "$report"
+  echo "Logs: \`$SESSION_DIR/\`" >> "$report"
+
+  log "report: $report"
+}
+
+# ── entry ───────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo "RWX CI Optimizer — CppDigest/llvm-project"
+  echo "sessions=$MAX_SESSIONS  iter/session=$MAX_ITERATIONS  target=${TARGET_RUNTIME_SECONDS}s  dry=$DRY_RUN"
+  echo ""
+
+  preflight
+
+  mkdir -p "$LOG_BASE_DIR"
+  touch "$BLOCKLIST_FILE"
+
+  for ((s=1; s<=MAX_SESSIONS; s++)); do
+    echo ""
+    echo "=== Session $s / $MAX_SESSIONS ==="
+    run_session "$s"
+  done
+
+  echo ""
+  echo "Done. Logs: $LOG_BASE_DIR"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `.rwx/ci.yml` — 15-task DAG migrated from `.ci/monolithic-linux.sh`
- Add `.rwx/optimizer.sh` — iterative Claude Code loop to fix/optimize the workflow

## Task DAG

clone → deps/sccache → cmake-configure → build-llvm-core → 10 parallel checks → report

Parallel checks: llvm, clang, lld, mlir, bolt, polly, flang, clang-tools, lldb, runtimes (compiler-rt + libcxx C++26 + Clang Modules)

## Key config choices

| Setting | Value | Why |
|---------|-------|-----|
| Build agent | 16 CPU / 64 GB | LLVM needs it; default 2/8 would OOM |
| Test agents | 4-8 CPU / 16-32 GB | Sized per subproject |
| sccache | 5G, workspace-relative, in filter | Cache persists across runs |
| Timeouts | 2m–90m per task | Default 10m too short for LLVM |
| Concurrency | cancel-waiting (main), cancel-running (PR) | Avoid wasted runs |
| Report task | after: expression | Runs even when checks fail |

## Status

Not yet tested — first `rwx run` needed to validate.

Closes #3